### PR TITLE
Avoid loading all tokens into memory

### DIFF
--- a/code_library/python3/scanner.py
+++ b/code_library/python3/scanner.py
@@ -3,16 +3,16 @@ import sys
 
 class Scanner():
     def __init__(self):
-        self.tokens = []
-        self.index = -1
-
-        for line in sys.stdin:
-            self.tokens.extend(line.split())
+        self.tokens = self.get_tokens()
 
     def next_token(self):
-        self.index += 1
-        return None if self.index == len(self.tokens) \
-            else self.tokens[self.index]
+        return next(self.tokens)
+
+    def get_tokens(self):
+        for line in sys.stdin:
+            for token in line.split():
+                yield token  
+        yield None
 
 
 def main():


### PR DESCRIPTION
This avoids loading all lines and tokens into memory, only accessing the file line by line as needed. It also removes error-prone index access

Running a perf test on a 5mb randomly generated file of numbers:

Previous perf stats: 
```
real 1.54s
user 1.37s
sys  0.17s
memory:175832KB
cpu 100%
```

Updated perf stats with changes introduced in this PR:
```
real 1.11s
user 1.09s
sys  0.01s
memory:6972KB
cpu 100%
```