### PR TITLE
Inline base read and write methods

### DIFF
--- a/code_library/fast_io.cpp
+++ b/code_library/fast_io.cpp
@@ -45,7 +45,7 @@ namespace fio{
     int buf_len = 0, inptr = 0, outptr = 0;
     char inbuf[BUF_SIZE], outbuf[BUF_SIZE], tmpbuf[128];
 
-    char read_char(){
+    inline char read_char(){
         if (inptr >= buf_len){
             inptr = 0, buf_len = fread(inbuf, 1, BUF_SIZE, stdin);
             if (buf_len == 0) return EOF;
@@ -123,7 +123,7 @@ namespace fio{
         outptr = 0;
     }
 
-    void write_char(const char& c){
+    inline void write_char(const char& c){
         if (outptr == BUF_SIZE) flush();
         outbuf[outptr++] = c;
     }


### PR DESCRIPTION
### Motivation
The basic methods, `read_char` and `write_char` are repeatedly executed from the other methods. Looking at the assembly, we can see that generated assembly for methods themselves are so tiny, that the cost of invoking them is more than the cost of actually running the methods themselves. Unfortunately since the methods are inside a `namespace` they are not automatically inlined as would happen if they were inside a `struct`/`class`, so we have to manually inline them.

### Comparison
Without inlining: https://godbolt.org/z/5rW4rPeT3
With inlining: https://godbolt.org/z/o5nrhYGdh

### Benchmark
On SPOJ INOUTTEST, this results in a ~30% speedup

Without inlining: https://vjudge.net/solution/31119043
With inlining: https://vjudge.net/solution/31119051

<hr />

### FAQ
#### 1. Why not inline the other methods?
Most of the other methods are quite complex, meaning that inlining them does not actually yield much of a benefit since, 

A) they are not called as much as `read_char` and `write_char`, 
B) the cost of invoking them is small compared to what actually goes on inside them. 

In some rare cases (e.g. for the vector case) the performance of the inlined version could actually be worse.
